### PR TITLE
Add new models support and delete deprecated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ DuckDuckGo AI to OpenAI API
 Model mapping, unsupported models default to `gpt-4o-mini`
 
 - gpt-4o-mini -> `gpt-4o-mini`
-- claude-3-haiku -> `claude-3-haiku-20240307`
-- llama-3.1-70b -> `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo`
-- mixtral-8x7b -> `mistralai/Mixtral-8x7B-Instruct-v0.1`
+- gpt-5-mini -> `gpt-5-mini`
+- claude-3.5-haiku -> `claude-3-5-haiku-latest`
+- llama-4-scout -> `meta-llama/Llama-4-Scout-17B-16E-Instruct`
+- mistral-small-3 -> `mistralai/Mistral-Small-24B-Instruct-2501`
 
 ## Chat
 

--- a/src/serve/model.rs
+++ b/src/serve/model.rs
@@ -75,10 +75,11 @@ where
 {
     let model = String::deserialize(deserializer)?;
     let model = match model.as_str() {
-        "claude-3-haiku" => "claude-3-haiku-20240307",
-        "llama-3.3-70b" => "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "claude-3.5-haiku" => "claude-3-5-haiku-latest",
+        "llama-4-scout" => "meta-llama/Llama-4-Scout-17B-16E-Instruct",
         "mistral-small-3" => "mistralai/Mistral-Small-24B-Instruct-2501",
-        "o3-mini" => "o3-mini",
+        "gpt-4o-mini" => "gpt-4o-mini",
+        "gpt-5-mini" => "gpt-5-mini"
         _ => "gpt-4o-mini",
     };
 


### PR DESCRIPTION
Some models, such as `o3-mini`, has been deprecated, while new models, such as `gpt-5-mini`, are now supported.    

<img width="590" height="868" alt="image" src="https://github.com/user-attachments/assets/db8855ba-d820-4f7f-bf0b-392fe85c7e1f" />  
<img width="935" height="287" alt="image" src="https://github.com/user-attachments/assets/2bc83777-ca62-4a57-b571-bd131426bda3" />
